### PR TITLE
Feature/allow skip verify iam cert

### DIFF
--- a/cmd/diwise-web/config.go
+++ b/cmd/diwise-web/config.go
@@ -29,6 +29,7 @@ const (
 	oauth2RealmURL
 	oauth2ClientID
 	oauth2ClientSecret
+	oauth2SkipVerify
 
 	contentSecurityPolicy
 )


### PR DESCRIPTION
When we run diwise-web locally we sometimes want to connect it to an IAM that uses a self signed certificate. This setting allows us to connect tot eh IAM without rejecting it due to the insecure cert.